### PR TITLE
Add the "added" callback option to stackedFormset and tabularFormset

### DIFF
--- a/nested_inline/static/admin/js/inlines-nested.js
+++ b/nested_inline/static/admin/js/inlines-nested.js
@@ -210,6 +210,8 @@
                 reinitDateTimeShortCuts();
                 updateSelectFilter();
                 alternatingRows(row);
+                if(options.added)
+                    options.added(row);
             }
         });
 
@@ -274,6 +276,8 @@
                 reinitDateTimeShortCuts();
                 updateSelectFilter();
                 update_inline_labels(row.parent());
+                if(options.added)
+                    options.added(row);
             })
         });
 


### PR DESCRIPTION
This change adds the `added` callback option that that exists for `formset` to `stackedFormset` and `tabularFormset`. It's used by Engage when adding multiple fields.